### PR TITLE
Adressed minor issues from GlaThiDa update

### DIFF
--- a/src/glaciers/glacier/glacier2D_utils.jl
+++ b/src/glaciers/glacier/glacier2D_utils.jl
@@ -264,7 +264,6 @@ function check_glathida_rgi_ids(target_rgi_ids)
         
         # Checking if the target RGI ID is in the rgi_ids array
         is_in_rgi_ids = target_rgi_id in rgi_ids
-        println("Is '$target_rgi_id' in GlaThiDa database? ", is_in_rgi_ids)
 
         # Add to the list if valid
         if is_in_rgi_ids

--- a/src/setup/helper_utilities.jl
+++ b/src/setup/helper_utilities.jl
@@ -11,11 +11,22 @@ function safe_approx(a, b)
     end
 end
 
-function get_property_or_zero_PyObject(obj, prop_name::Symbol)
+# Function for Python objects
+function safe_getproperty(obj::PyObject, prop_name::Symbol)
     if PyCall.hasproperty(obj, prop_name)
         return PyCall.getproperty(obj, prop_name)
     else
         return 0.0
     end
 end
+
+# Function for Julia objects
+function safe_getproperty(obj, prop_name::Symbol)
+    if hasproperty(obj, prop_name)
+        return getproperty(obj, prop_name)
+    else
+        return 0.0
+    end
+end
+
     

--- a/src/simulations/results/results_utils.jl
+++ b/src/simulations/results/results_utils.jl
@@ -17,8 +17,8 @@ function create_results(simulation::SIM, glacier_idx::I, solution; light=false) 
                       Vy = simulation.model.iceflow.Vy,
                       Δx = simulation.glaciers[glacier_idx].Δx,              
                       Δy = simulation.glaciers[glacier_idx].Δy,
-                      lon = get_property_or_zero_PyObject(simulation.glaciers[glacier_idx].gdir, :cenlon),
-                      lat = get_property_or_zero_PyObject(simulation.glaciers[glacier_idx].gdir, :cenlat)
+                      lon = safe_getproperty(simulation.glaciers[glacier_idx].gdir, :cenlon),
+                      lat = safe_getproperty(simulation.glaciers[glacier_idx].gdir, :cenlat)
 )              
                       
     return results


### PR DESCRIPTION
- Removed the printing of checking if glaciers are in GlaThiDa database. 
- Improved name of helper function and made it useable for Python Objects and Julia Objects

Clarification on helper function: 
Five tests in Huginn involve glaciers lacking a 'gdir'. The 'create_results()' function extracts longitude and latitude indirectly from the 'gdir'. This helper function `safe_getproperty()` makes sure that if the glacier has no gdir it still assigns a value (of zero) to the longitude and latitude. Acting as a workaround to accommodate glaciers without gdir.