### PR TITLE
Fix: add comma in Dict

### DIFF
--- a/src/glaciers/climate/Climate2D.jl
+++ b/src/glaciers/climate/Climate2D.jl
@@ -266,6 +266,8 @@ end
 function Base.:(==)(a::Climate2D, b::Climate2D)
     a.raw_climate == b.raw_climate && a.climate_raw_step == b.climate_raw_step &&
         a.climate_step == b.climate_step && a.climate_2D_step == b.climate_2D_step &&
+        # Some properties are checked approximatively because of numerical rounding
+        # varying depending on the platform, which results in different values
         a.longterm_temps_scalar ≈ b.longterm_temps_scalar &&
         a.longterm_temps_gridded ≈ b.longterm_temps_gridded &&
         a.avg_temps ≈ b.avg_temps &&
@@ -290,7 +292,8 @@ end
 
 """
     DummyClimate2D(;
-        longterm_temps::Vector{F} = []
+        longterm_temps_scalar::Vector{F} = Vector{Sleipnir.Float}([]),
+        longterm_temps_gridded::Matrix{F} = Matrix{Sleipnir.Float}(zeros(0, 0))
     ) where {F <: AbstractFloat}
 
 Dummy climate initialization for very specific use cases where we don't have climate
@@ -300,7 +303,8 @@ It returns a minimalistic Climate2D instance.
 
 Arguments:
 
-  - `longterm_temps::Vector{F}`: Long term temperatures.
+  - `longterm_temps_scalar::Vector{F}`: Scalar long term temperatures.
+  - `longterm_temps_gridded::Matrix{F}`: Distributed long term temperatures (matrix).
 """
 function DummyClimate2D(;
         longterm_temps_scalar::Vector{F} = Vector{Sleipnir.Float}([]),

--- a/src/glaciers/climate/Climate2D.jl
+++ b/src/glaciers/climate/Climate2D.jl
@@ -281,9 +281,9 @@ function diffToDict(a::Climate2D, b::Climate2D)
         :climate_raw_step => a.climate_raw_step == b.climate_raw_step,
         :climate_step => a.climate_step == b.climate_step,
         :climate_2D_step => a.climate_2D_step == b.climate_2D_step,
-        :longterm_temps_scalar => a.longterm_temps_scalar == b.longterm_temps_scalar,
-        :longterm_temps_gridded => a.longterm_temps_gridded == b.longterm_temps_gridded,
-        :avg_temps => a.avg_temps == b.avg_temps,
+        :longterm_temps_scalar => a.longterm_temps_scalar ≈ b.longterm_temps_scalar,
+        :longterm_temps_gridded => a.longterm_temps_gridded ≈ b.longterm_temps_gridded,
+        :avg_temps => a.avg_temps ≈ b.avg_temps,
         :avg_gradients => a.avg_gradients == b.avg_gradients,
         :ref_hgt => a.ref_hgt == b.ref_hgt,
         :climate_data_source => a.climate_data_source == b.climate_data_source

--- a/src/glaciers/glacier/Glacier2D.jl
+++ b/src/glaciers/glacier/Glacier2D.jl
@@ -320,6 +320,7 @@ function diffToDict(a::Glacier2D, b::Glacier2D)
         :mask_loss => a.mask_loss == b.mask_loss,
         :Coords => a.Coords == b.Coords,
         :Δx => a.Δx == b.Δx,
+        :Δy => a.Δy == b.Δy,
         :nx => a.nx == b.nx,
         :ny => a.ny == b.ny,
         :cenlon => a.cenlon == b.cenlon,
@@ -327,7 +328,7 @@ function diffToDict(a::Glacier2D, b::Glacier2D)
         :params_projection => a.params_projection == b.params_projection,
         :thicknessData => a.thicknessData == b.thicknessData,
         :velocityData => a.velocityData == b.velocityData,
-        :dhdtData => a.dhdtData == b.dhdtData,
+        :dhdtData => a.dhdtData == b.dhdtData
     )
 end
 

--- a/src/glaciers/glacier/Glacier2D.jl
+++ b/src/glaciers/glacier/Glacier2D.jl
@@ -92,7 +92,7 @@ end
     Glacier2D(;
         rgi_id::String = "",
         name::String = "",
-        climate::Climate2D = nothing,
+        climate::Union{Climate2D, Nothing} = nothing,
         H₀::Matrix{F} = Matrix{Sleipnir.Float}([;;]),
         H_glathida::Matrix{F} = Matrix{Sleipnir.Float}([;;]),
         S::Matrix{F} = Matrix{Sleipnir.Float}([;;]),
@@ -134,7 +134,7 @@ Constructs a `Glacier2D` object with the given parameters, including default one
 
   - `rgi_id::String`: The RGI identifier for the glacier.
   - `name::String`: The name of the glacier if available.
-  - `climate::Climate2D`: The climate data associated with the glacier.
+  - `climate::Union{Climate2D, Nothing}`: The climate data associated with the glacier. Defaults to `nothing` which falls back to `DummyClimate2D()`.
   - `H₀::Matrix{F}`: Initial ice thickness matrix.
   - `H_glathida::Matrix{F}`: Ice thickness matrix from GLATHIDA.
   - `S::Matrix{F}`: Surface elevation matrix.
@@ -170,7 +170,7 @@ Constructs a `Glacier2D` object with the given parameters, including default one
 function Glacier2D(;
         rgi_id::String = "",
         name::String = "",
-        climate::Climate2D = nothing,
+        climate::Union{Climate2D, Nothing} = nothing,
         H₀::Matrix{F} = Matrix{Sleipnir.Float}(undef, 0, 0),
         H_glathida::Matrix{F} = Matrix{Sleipnir.Float}(undef, 0, 0),
         S::Matrix{F} = Matrix{Sleipnir.Float}(undef, 0, 0),
@@ -206,6 +206,9 @@ function Glacier2D(;
         SURFVELDATA <: Union{<:SurfaceVelocityData, Nothing},
         DHDTDATA <: Union{<:DhdtData, Nothing}
 }
+    if isnothing(climate)
+        climate = DummyClimate2D()
+    end
     return Glacier2D{Sleipnir.Float, Sleipnir.Int, typeof(climate),
         typeof(thicknessData), typeof(velocityData), typeof(dhdtData)}(
         rgi_id, name, climate, H₀, H_glathida,
@@ -335,7 +338,8 @@ end
 # Display setup
 Base.show(io::IO, type::MIME"text/plain", glacier::Glacier2D) = Base.show(io, glacier)
 function Base.show(io::IO, glacier::Glacier2D)
-    if !isnothing(glacier.H₀)
+    validGrid = !isnothing(glacier.H₀) && length(glacier.H₀) > 0
+    if validGrid
         H = round.(255 * glacier.H₀ / maximum(glacier.H₀))
         display(Gray.(Int.(H') / 255))
     end
@@ -363,14 +367,16 @@ function Base.show(io::IO, glacier::Glacier2D)
     end
     println(io, " glathida elevation")
 
-    print(io, "Min,mean,max bedrock elevation S : ")
-    printstyled(io,
-        "$(round(minimum(glacier.S[glacier.H₀.>0]);digits=1)) $(round(mean(glacier.S[glacier.H₀.>0]);digits=1)) $(round(maximum(glacier.S[glacier.H₀.>0]);digits=1))\n";
-        color = :blue)
-    print(io, "Mean,max ice thickness H₀ : ")
-    printstyled(io,
-        "$(round(mean(glacier.H₀[glacier.H₀.>0]);digits=1)) $(round(maximum(glacier.H₀[glacier.H₀.>0]);digits=1))\n";
-        color = :blue)
+    if validGrid
+        print(io, "Min,mean,max bedrock elevation S : ")
+        printstyled(io,
+            "$(round(minimum(glacier.S[glacier.H₀.>0]);digits=1)) $(round(mean(glacier.S[glacier.H₀.>0]);digits=1)) $(round(maximum(glacier.S[glacier.H₀.>0]);digits=1))\n";
+            color = :blue)
+        print(io, "Mean,max ice thickness H₀ : ")
+        printstyled(io,
+            "$(round(mean(glacier.H₀[glacier.H₀.>0]);digits=1)) $(round(maximum(glacier.H₀[glacier.H₀.>0]);digits=1))\n";
+            color = :blue)
+    end
 
     print(io, "A = ")
     printstyled(io, @sprintf("%.3e", glacier.A); color = :blue)

--- a/src/glaciers/glacier/Glacier2D.jl
+++ b/src/glaciers/glacier/Glacier2D.jl
@@ -326,9 +326,8 @@ function diffToDict(a::Glacier2D, b::Glacier2D)
         :cenlat => a.cenlat == b.cenlat,
         :params_projection => a.params_projection == b.params_projection,
         :thicknessData => a.thicknessData == b.thicknessData,
-        :velocityData => a.velocityData ==
-                         b.velocityData
-        :dhdtData => a.dhdtData == b.dhdtData
+        :velocityData => a.velocityData == b.velocityData,
+        :dhdtData => a.dhdtData == b.dhdtData,
     )
 end
 

--- a/src/setup/helper_utilities.jl
+++ b/src/setup/helper_utilities.jl
@@ -1,11 +1,14 @@
 export safe_approx
 
-# Function to override "≈" to handle nothing values
+# Function to override "≈" to handle nothing values and dict
 function safe_approx(a, b)
     if isnothing(a) && isnothing(b)
         return true
     elseif isnothing(a) || isnothing(b)
         return false
+    elseif (a isa Dict) && (b isa Dict)
+        keys(a) == keys(b) || return false
+        return all(a[k] ≈ b[k] for k in keys(a))
     else
         return a ≈ b
     end

--- a/test/glaciers_construction.jl
+++ b/test/glaciers_construction.jl
@@ -1,4 +1,9 @@
 
+function glaciers2D_simple_constructor()
+    glacier = Glacier2D()
+    println(glacier)
+end
+
 function glaciers2D_constructor(; save_refs::Bool = false, use_glathida_data::Bool = false)
     rgi_paths = get_rgi_paths()
     if use_glathida_data
@@ -63,5 +68,6 @@ function glaciers2D_constructor(; save_refs::Bool = false, use_glathida_data::Bo
             end
         end
     end
-    @test all(glaciers == glaciers_ref)
+    @test all(glaciers ≈ glaciers_ref) # Test approximate equality
+    @test all(glaciers == glaciers_ref) # Test exact equality
 end

--- a/test/glaciers_construction.jl
+++ b/test/glaciers_construction.jl
@@ -68,6 +68,6 @@ function glaciers2D_constructor(; save_refs::Bool = false, use_glathida_data::Bo
             end
         end
     end
-    @test all(glaciers ≈ glaciers_ref) # Test approximate equality
-    @test all(glaciers == glaciers_ref) # Test exact equality
+    @test all(glaciers .≈ glaciers_ref) # Test approximate equality
+    @test all(glaciers .== glaciers_ref) # Test exact equality
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,7 @@ ENV["GKSwstype"]="nul"
     @testset "Constructors" begin
         @testset "Parameters constructors with specified values" params_constructor_specified(save_refs = false)
         @testset "Parameters constructors by default" params_constructor_default(save_refs = false)
+        @testset "Glaciers 2D minimalistic constructors" glaciers2D_simple_constructor()
         @testset "Glaciers 2D constructors w/o glathida data" glaciers2D_constructor(
             use_glathida_data = false, save_refs = false)
         @testset "Glaciers 2D constructors w/ glathida data" glaciers2D_constructor(


### PR DESCRIPTION
Add trailing comma to:
```julia
:velocityData => a.velocityData == b.velocityData
```
which otherwise should be a syntax error, I think(?)

It also seems that `:Δy` is missing entirely (only `:Δx` appears). The corresponding `Base.(==)` function _does_ check `Δy` for a pair of glaciers[^1].

[^1]: Relatedly, the corresponding function for `Climate2D`: `diffToDict(a::Climate2D, b::Climate2D)` does: `:avg_temps => a.avg_temps == b.avg_temps`, while `Base.:(==)(a::Climate2D, b::Climate2D)` does: `a.avg_temps ≈ b.avg_temps` (equality vs approximation); an issue that also appears for a few other variables..


---

It also appears that no test currently exercises this function, which would be good to add (feel free to edit this PR).

I was not able to verify this locally since I needed to construct a `Glacier2D` object, and the "default" (no arg) constructor for `Glacier2D` doesn't work (it expects a `Climate2D` instance, which the docstring does not clearly explain how to create in isolation).
- I see that the tests/scripts have some "toy" and "dummy" variants, which would be useful to surface in user/developer facing docs. Related to https://github.com/ODINN-SciML/Sleipnir.jl/issues/173 and https://github.com/ODINN-SciML/ODINN.jl/issues/492

---

xref: https://github.com/openjournals/joss-reviews/issues/10528