### PR TITLE
Utils to assimilate Millan22 velocities + fix tstops mismatch

### DIFF
--- a/src/glaciers/glacier/glacier2D_utils.jl
+++ b/src/glaciers/glacier/glacier2D_utils.jl
@@ -1,5 +1,5 @@
 
-export initialize_glaciers, initialize_glacier_with_millan
+export initialize_glaciers
 export generate_ground_truth, generate_ground_truth!
 export is_in_glacier
 export glacierName

--- a/src/glaciers/glacier/glacier2D_utils.jl
+++ b/src/glaciers/glacier/glacier2D_utils.jl
@@ -317,6 +317,26 @@ function convertRasterStackToFloat64(rs::RasterStack)
     )
 end
 
+function _process_Millan22_velocities(params, glacier_gd)
+    if params.simulation.gridScalingFactor > 1
+        Vx = block_average_pad_edge_masked(
+            glacier_gd.millan_vx.data, glacier_gd.glacier_mask.data .== 1,
+            params.simulation.gridScalingFactor; empty_value = 0.0)
+        Vy = block_average_pad_edge_masked(
+            glacier_gd.millan_vy.data, glacier_gd.glacier_mask.data .== 1,
+            params.simulation.gridScalingFactor; empty_value = 0.0)
+        V = (Vx .^ 2+Vy .^ 2) .^ (0.5)
+    else
+        V = ifelse.(glacier_gd.glacier_mask.data .== 1, glacier_gd.millan_v.data, 0.0)
+        Vx = ifelse.(glacier_gd.glacier_mask.data .== 1, glacier_gd.millan_vx.data, 0.0)
+        Vy = ifelse.(glacier_gd.glacier_mask.data .== 1, glacier_gd.millan_vy.data, 0.0)
+        fillNaN!(V)
+        fillNaN!(Vx)
+        fillNaN!(Vy)
+    end
+    return V, Vy, Vy
+end
+
 function _build_glacier(params, glacier_gd, masking, masking_loss, glacier_grid, H₀, rgi_id)
     # We filter glacier borders in high elevations to avoid overflow problems
     dist_border::Matrix{Sleipnir.Float} = glacier_gd.dis_from_border.data
@@ -372,22 +392,7 @@ function _build_glacier(params, glacier_gd, masking, masking_loss, glacier_grid,
     Coords = Dict{String, Vector{Float64}}("lon" => longitudes, "lat" => latitudes)
 
     if params.simulation.use_velocities
-        if params.simulation.gridScalingFactor > 1
-            Vx = block_average_pad_edge_masked(
-                glacier_gd.millan_vx.data, glacier_gd.glacier_mask.data .== 1,
-                params.simulation.gridScalingFactor; empty_value = 0.0)
-            Vy = block_average_pad_edge_masked(
-                glacier_gd.millan_vy.data, glacier_gd.glacier_mask.data .== 1,
-                params.simulation.gridScalingFactor; empty_value = 0.0)
-            V = (Vx .^ 2+Vy .^ 2) .^ (0.5)
-        else
-            V = ifelse.(glacier_gd.glacier_mask.data .== 1, glacier_gd.millan_v.data, 0.0)
-            Vx = ifelse.(glacier_gd.glacier_mask.data .== 1, glacier_gd.millan_vx.data, 0.0)
-            Vy = ifelse.(glacier_gd.glacier_mask.data .== 1, glacier_gd.millan_vy.data, 0.0)
-            fillNaN!(V)
-            fillNaN!(Vx)
-            fillNaN!(Vy)
-        end
+        V, Vy, Vy = _process_Millan22_velocities(params, glacier_gd)
     else
         V = zeros(Sleipnir.Float, size(H₀))
         Vx = zeros(Sleipnir.Float, size(H₀))
@@ -541,7 +546,6 @@ function Glacier2D(
     end
 end
 
-
 """
     generate_ground_truth!(glacier::Glacier2D, params::Parameters)
 
@@ -562,15 +566,7 @@ function generate_ground_truth!(
         glacier_gd = convertRasterStackToFloat64(glacier_gd)
     end
 
-    mask = glacier_gd.glacier_mask.data .== 1
-
-    vx_mat = ifelse.(mask, glacier_gd.millan_vx.data, NaN)
-    vy_mat = ifelse.(mask, glacier_gd.millan_vy.data, NaN)
-    vabs_mat = ifelse.(mask, glacier_gd.millan_v.data, NaN)
-
-    fillNaN!(vx_mat)
-    fillNaN!(vy_mat)
-    fillNaN!(vabs_mat)
+    vabs_mat, vy_mat, vx_mat = _process_Millan22_velocities(params, glacier_gd)
 
     MILLAN22_DATE1 = Dates.DateTime(2017, 1, 1)
     MILLAN22_DATE2 = Dates.DateTime(2018, 1, 1)
@@ -585,13 +581,13 @@ function generate_ground_truth!(
         vx = [vx_mat],
         vy = [vy_mat],
         vabs = [vabs_mat],
-        isGridGlacierAligned = true,
+        isGridGlacierAligned = true
     )
 
-    thicknessData = ThicknessData(
-        t = [datetime_to_floatyear(date_mean)], 
-        H = [glacier.H₀]
-    )
+    # thicknessData = ThicknessData(
+    #     t = [datetime_to_floatyear(date_mean)],
+    #     H = [glacier.H₀]
+    # )
 
     #return Glacier2D(glacier; thicknessData = thicknessData, velocityData = velocityData)
     return Glacier2D(glacier; velocityData = velocityData)
@@ -610,7 +606,6 @@ function generate_ground_truth(
 )
     return map(glacier -> generate_ground_truth!(glacier, params), glaciers)
 end
-
 
 # [Begin] Glathida Utilities
 """

--- a/src/glaciers/glacier/glacier2D_utils.jl
+++ b/src/glaciers/glacier/glacier2D_utils.jl
@@ -1,6 +1,6 @@
 
 export initialize_glaciers, initialize_glacier_with_millan
-export generate_ground_truth, generate_ground_truth!, Millan22
+export generate_ground_truth, generate_ground_truth!
 export is_in_glacier
 export glacierName
 export compute_surface_topography, compute_surface_slope, compute_surface_aspect
@@ -334,7 +334,7 @@ function _process_Millan22_velocities(params, glacier_gd)
         fillNaN!(Vx)
         fillNaN!(Vy)
     end
-    return V, Vy, Vy
+    return V, Vx, Vy
 end
 
 function _build_glacier(params, glacier_gd, masking, masking_loss, glacier_grid, H₀, rgi_id)
@@ -392,7 +392,7 @@ function _build_glacier(params, glacier_gd, masking, masking_loss, glacier_grid,
     Coords = Dict{String, Vector{Float64}}("lon" => longitudes, "lat" => latitudes)
 
     if params.simulation.use_velocities
-        V, Vy, Vy = _process_Millan22_velocities(params, glacier_gd)
+        V, Vx, Vy = _process_Millan22_velocities(params, glacier_gd)
     else
         V = zeros(Sleipnir.Float, size(H₀))
         Vx = zeros(Sleipnir.Float, size(H₀))

--- a/src/glaciers/glacier/glacier2D_utils.jl
+++ b/src/glaciers/glacier/glacier2D_utils.jl
@@ -1,6 +1,5 @@
 
 export initialize_glaciers
-export generate_ground_truth, generate_ground_truth!
 export is_in_glacier
 export glacierName
 export compute_surface_topography, compute_surface_slope, compute_surface_aspect
@@ -53,8 +52,8 @@ function _centered_gradients(
         dSdx[end, :] .= dSdx_edges[end, :]
         if nx > 2
             dSdx[2:(end - 1),
-            :] .= 0.5 .*
-                                    (dSdx_edges[1:(end - 1), :] .+ dSdx_edges[2:end, :])
+                :] .= 0.5 .*
+                      (dSdx_edges[1:(end - 1), :] .+ dSdx_edges[2:end, :])
         end
     end
 
@@ -64,8 +63,8 @@ function _centered_gradients(
         dSdy[:, end] .= dSdy_edges[:, end]
         if ny > 2
             dSdy[:,
-            2:(end - 1)] .= 0.5 .*
-                                    (dSdy_edges[:, 1:(end - 1)] .+ dSdy_edges[:, 2:end])
+                2:(end - 1)] .= 0.5 .*
+                                (dSdy_edges[:, 1:(end - 1)] .+ dSdy_edges[:, 2:end])
         end
     end
 
@@ -398,6 +397,25 @@ function _build_glacier(params, glacier_gd, masking, masking_loss, glacier_grid,
         Vx = zeros(Sleipnir.Float, size(H₀))
         Vy = zeros(Sleipnir.Float, size(H₀))
     end
+    if params.simulation.velocity_product == :Millan22
+        MILLAN22_DATE1 = Dates.DateTime(2017, 1, 1)
+        MILLAN22_DATE2 = Dates.DateTime(2018, 1, 1)
+
+        delta = MILLAN22_DATE2 - MILLAN22_DATE1
+        date_mean = MILLAN22_DATE1 + Dates.Millisecond(div(Dates.value(delta), 2))
+
+        velocityData = SurfaceVelocityData(
+            date = [date_mean],
+            date1 = [MILLAN22_DATE1],
+            date2 = [MILLAN22_DATE2],
+            vx = [Vx],
+            vy = [Vy],
+            vabs = [V],
+            isGridGlacierAligned = true
+        )
+    else
+        velocityData = nothing
+    end
     Δx::Sleipnir.Float = abs.(glacier_grid["dxdy"][1])
     Δy::Sleipnir.Float = abs.(glacier_grid["dxdy"][2])
     if params.simulation.gridScalingFactor > 1
@@ -422,7 +440,8 @@ function _build_glacier(params, glacier_gd, masking, masking_loss, glacier_grid,
         mask = mask, mask_loss = mask_loss,
         Coords = Coords, Δx = Δx, Δy = Δy, nx = nx, ny = ny,
         cenlon = cenlon, cenlat = cenlat,
-        params_projection = params_projection
+        params_projection = params_projection,
+        velocityData = velocityData
     )
 end
 
@@ -546,67 +565,6 @@ function Glacier2D(
     end
 end
 
-"""
-    generate_ground_truth!(glacier::Glacier2D, params::Parameters)
-
-Attach Millan ground-truth data to a single `Glacier2D` object.
-
-This function loads the Millan 2022 velocity rasters for the glacier,
-builds a matching `SurfaceVelocityData`, and creates a `ThicknessData` entry
-at the mean acquisition date of the fixed Millan acquisition window.
-It returns a new `Glacier2D` copy with both fields attached.
-"""
-function generate_ground_truth!(
-        glacier::Glacier2D,
-        params::Parameters
-)
-    rgi_path = joinpath(prepro_dir, params.simulation.rgi_paths[glacier.rgi_id])
-    glacier_gd = RasterStack(joinpath(rgi_path, "gridded_data.nc"))
-    if Sleipnir.doublePrec
-        glacier_gd = convertRasterStackToFloat64(glacier_gd)
-    end
-
-    vabs_mat, vy_mat, vx_mat = _process_Millan22_velocities(params, glacier_gd)
-
-    MILLAN22_DATE1 = Dates.DateTime(2017, 1, 1)
-    MILLAN22_DATE2 = Dates.DateTime(2018, 1, 1)
-
-    delta = MILLAN22_DATE2 - MILLAN22_DATE1
-    date_mean = MILLAN22_DATE1 + Dates.Millisecond(div(Dates.value(delta), 2))
-
-    velocityData = SurfaceVelocityData(
-        date = [date_mean],
-        date1 = [MILLAN22_DATE1],
-        date2 = [MILLAN22_DATE2],
-        vx = [vx_mat],
-        vy = [vy_mat],
-        vabs = [vabs_mat],
-        isGridGlacierAligned = true
-    )
-
-    # thicknessData = ThicknessData(
-    #     t = [datetime_to_floatyear(date_mean)],
-    #     H = [glacier.H₀]
-    # )
-
-    #return Glacier2D(glacier; thicknessData = thicknessData, velocityData = velocityData)
-    return Glacier2D(glacier; velocityData = velocityData)
-end
-
-"""
-    generate_ground_truth(glaciers::AbstractVector{<:Glacier2D}, params::Parameters)
-
-Vectorized version of `generate_ground_truth!` for a collection of glaciers.
-Each glacier is updated independently and the function returns a new vector of
-`Glacier2D` objects with Millan thickness and velocity data attached.
-"""
-function generate_ground_truth(
-        glaciers::AbstractVector{<:Glacier2D},
-        params::Parameters
-)
-    return map(glacier -> generate_ground_truth!(glacier, params), glaciers)
-end
-
 # [Begin] Glathida Utilities
 """
     get_glathida!(glaciers::Vector{G}, params::Parameters; force=false) where {G <: Glacier2D}
@@ -689,8 +647,7 @@ function get_glathida_glacier(glacier::Glacier2D, params::Parameters, force)
         glathida = CSV.File(joinpath(rgi_path, "glathida_data.csv"))
         gtd_grid = zeros(size(glacier.H₀))
         count = zeros(size(glacier.H₀))
-        for (thick, i, j) in
-            zip(glathida["thickness"], glathida["i_grid"], glathida["j_grid"])
+        for (thick, i, j) in zip(glathida["thickness"], glathida["i_grid"], glathida["j_grid"])
             count[i, j] += 1
             gtd_grid[i, j] += thick
         end
@@ -965,10 +922,10 @@ The function updates the interior elements of `A` (excluding the boundary elemen
 """
 @views function smooth!(A)
     A[2:(end - 1),
-    2:(end - 1)] .= A[2:(end - 1), 2:(end - 1)] .+
-                                   1.0 ./ 4.1 .*
-                                   (diff(diff(A[:, 2:(end - 1)], dims = 1), dims = 1) .+
-                                    diff(diff(A[2:(end - 1), :], dims = 2), dims = 2))
+        2:(end - 1)] .= A[2:(end - 1), 2:(end - 1)] .+
+                        1.0 ./ 4.1 .*
+                        (diff(diff(A[:, 2:(end - 1)], dims = 1), dims = 1) .+
+                         diff(diff(A[2:(end - 1), :], dims = 2), dims = 2))
     A[1, :]=A[2, :];
     A[end, :]=A[end - 1, :];
     A[:, 1]=A[:, 2];

--- a/src/glaciers/glacier/glacier2D_utils.jl
+++ b/src/glaciers/glacier/glacier2D_utils.jl
@@ -1,5 +1,6 @@
 
-export initialize_glaciers
+export initialize_glaciers, initialize_glacier_with_millan
+export generate_ground_truth, generate_ground_truth!, Millan22
 export is_in_glacier
 export glacierName
 export compute_surface_topography, compute_surface_slope, compute_surface_aspect
@@ -539,6 +540,77 @@ function Glacier2D(
             params, glacier_gd, masking, masking_loss, glacier_grid, H₀, rgi_id)
     end
 end
+
+
+"""
+    generate_ground_truth!(glacier::Glacier2D, params::Parameters)
+
+Attach Millan ground-truth data to a single `Glacier2D` object.
+
+This function loads the Millan 2022 velocity rasters for the glacier,
+builds a matching `SurfaceVelocityData`, and creates a `ThicknessData` entry
+at the mean acquisition date of the fixed Millan acquisition window.
+It returns a new `Glacier2D` copy with both fields attached.
+"""
+function generate_ground_truth!(
+        glacier::Glacier2D,
+        params::Parameters
+)
+    rgi_path = joinpath(prepro_dir, params.simulation.rgi_paths[glacier.rgi_id])
+    glacier_gd = RasterStack(joinpath(rgi_path, "gridded_data.nc"))
+    if Sleipnir.doublePrec
+        glacier_gd = convertRasterStackToFloat64(glacier_gd)
+    end
+
+    mask = glacier_gd.glacier_mask.data .== 1
+
+    vx_mat = ifelse.(mask, glacier_gd.millan_vx.data, NaN)
+    vy_mat = ifelse.(mask, glacier_gd.millan_vy.data, NaN)
+    vabs_mat = ifelse.(mask, glacier_gd.millan_v.data, NaN)
+
+    fillNaN!(vx_mat)
+    fillNaN!(vy_mat)
+    fillNaN!(vabs_mat)
+
+    MILLAN22_DATE1 = Dates.DateTime(2017, 1, 1)
+    MILLAN22_DATE2 = Dates.DateTime(2018, 1, 1)
+
+    delta = MILLAN22_DATE2 - MILLAN22_DATE1
+    date_mean = MILLAN22_DATE1 + Dates.Millisecond(div(Dates.value(delta), 2))
+
+    velocityData = SurfaceVelocityData(
+        date = [date_mean],
+        date1 = [MILLAN22_DATE1],
+        date2 = [MILLAN22_DATE2],
+        vx = [vx_mat],
+        vy = [vy_mat],
+        vabs = [vabs_mat],
+        isGridGlacierAligned = true,
+    )
+
+    thicknessData = ThicknessData(
+        t = [datetime_to_floatyear(date_mean)], 
+        H = [glacier.H₀]
+    )
+
+    #return Glacier2D(glacier; thicknessData = thicknessData, velocityData = velocityData)
+    return Glacier2D(glacier; velocityData = velocityData)
+end
+
+"""
+    generate_ground_truth(glaciers::AbstractVector{<:Glacier2D}, params::Parameters)
+
+Vectorized version of `generate_ground_truth!` for a collection of glaciers.
+Each glacier is updated independently and the function returns a new vector of
+`Glacier2D` objects with Millan thickness and velocity data attached.
+"""
+function generate_ground_truth(
+        glaciers::AbstractVector{<:Glacier2D},
+        params::Parameters
+)
+    return map(glacier -> generate_ground_truth!(glacier, params), glaciers)
+end
+
 
 # [Begin] Glathida Utilities
 """

--- a/src/parameters/SimulationParameters.jl
+++ b/src/parameters/SimulationParameters.jl
@@ -21,6 +21,7 @@ A structure to hold simulation parameters for a simulation in ODINN.
   - `test_mode::Bool`: Flag to indicate whether to run in test mode.
   - `rgi_paths::Dict{String, String}`: Dictionary of RGI paths.
   - `ice_thickness_source::Symbol`: Source of ice thickness data.
+  - `velocity_product::Union{Symbol, Nothing}`: Source of velocity product data.
   - `mapping::VM`: Mapping to use in order to grid the data from the coordinates of
     the velocity product datacube to the glacier grid.
   - `gridScalingFactor::I`: Grid downscaling factor, used to speed-up the tests.
@@ -44,6 +45,7 @@ struct SimulationParameters{I <: Integer, F <: AbstractFloat, VM <: VelocityMapp
     test_mode::Bool
     rgi_paths::Dict{String, String}
     ice_thickness_source::Symbol
+    velocity_product::Union{Symbol, Nothing}
     climate_data_source::Symbol
     mapping::VM
     gridScalingFactor::I
@@ -69,6 +71,7 @@ Constructor for `SimulationParameters` type, including default values.
         test_mode::Bool = false,
         rgi_paths::Dict{String, String} = Dict{String, String}(),
         ice_thickness_source::Symbol = :Farinotti19,
+        velocity_product::Union{Symbol, Nothing} = :Millan22,
         climate_data_source::Symbol = :W5E5,
         mapping::VM = MeanDateVelocityMapping(),
         gridScalingFactor::I = 1,
@@ -84,6 +87,7 @@ Constructor for `SimulationParameters` type, including default values.
   - `f_surface_velocity_factor::F`: Numerical factor representing the ratio between depth integrated ice velocity and surface velocity (default: `1.0`).
   - `overwrite_climate::Bool`: Whether to overwrite climate data (default: `false`).
   - `use_glathida_data::Bool`: Whether to use GLATHIDA data (default: `false`).
+  - `velocity_product::Union{Symbol, Nothing}`: Source of velocity product data (default: `:Millan22`).
   - `float_type::DataType`: Data type for floating point numbers (default: `Float64`).
   - `int_type::DataType`: Data type for integers (default: `Int64`).
   - `tspan::Tuple{F, F}`: Time span for the simulation (default: `(2010.0, 2015.0)`).
@@ -133,14 +137,18 @@ function SimulationParameters(;
         test_mode::Bool = false,
         rgi_paths::Dict{String, String} = Dict{String, String}(),
         ice_thickness_source::Symbol = :Farinotti19,
+        velocity_product::Union{Symbol, Nothing} = :Millan22,
         climate_data_source::Symbol = :W5E5,
         mapping::VM = MeanDateVelocityMapping(),
         gridScalingFactor::I = 1,
         catch_errors::Bool = false
 ) where {I <: Integer, F <: AbstractFloat, VM <: VelocityMapping}
     ice_thickness_source_sym = Symbol(ice_thickness_source)
+    velocity_product_sym = Symbol(velocity_product)
     @assert ((ice_thickness_source_sym == :Millan22) ||
              (ice_thickness_source_sym == :Farinotti19)) "Wrong ice thickness source! Should be either `:Millan22` or `:Farinotti19`."
+    @assert ((velocity_product_sym == :Millan22) ||
+             (velocity_product_sym == :nothing)) "Wrong velocity product source! Should be either `:Millan22` or `:nothing`."
 
     simulation_parameters = SimulationParameters(
         use_MB, use_iceflow, plots,
@@ -148,7 +156,8 @@ function SimulationParameters(;
         overwrite_climate, use_glathida_data,
         Sleipnir.Float.(tspan), Sleipnir.Float(step_MB),
         multiprocessing, Sleipnir.Int(workers), working_dir,
-        test_mode, rgi_paths, ice_thickness_source_sym, climate_data_source, mapping,
+        test_mode, rgi_paths, ice_thickness_source_sym, velocity_product_sym,
+        climate_data_source, mapping,
         gridScalingFactor, catch_errors
     )
 
@@ -175,6 +184,7 @@ function Base.:(==)(a::SimulationParameters, b::SimulationParameters)
         a.test_mode == b.test_mode &&
         a.rgi_paths == b.rgi_paths &&
         a.ice_thickness_source == b.ice_thickness_source &&
+        a.velocity_product == b.velocity_product &&
         a.climate_data_source == b.climate_data_source &&
         a.mapping == b.mapping &&
         a.gridScalingFactor == b.gridScalingFactor &&
@@ -224,6 +234,10 @@ function Base.show(io::IO, params::SimulationParameters)
     field(io, "ice_thickness");
     print(io, " = ");
     val(io, ":$(params.ice_thickness_source)")
+    sep(io)
+    field(io, "velocity_product");
+    print(io, " = ");
+    val(io, ":$(params.velocity_product)")
     sep(io)
     field(io, "climate");
     print(io, " = ");

--- a/src/simulations/results/results_utils.jl
+++ b/src/simulations/results/results_utils.jl
@@ -39,12 +39,12 @@ Vector of indices such that `t[indices]` are the times in `t` closest to each va
 
   - For the initial time step (`tspan[1]`), returns the first matching index to avoid out-of-range interpolation
   - For subsequent time steps, returns the last matching index to capture state after potential callbacks
-  - Uses approximate equality with relative tolerance `rtol=1e-7` to handle numerical rounding
+  - Uses approximate equality with relative tolerance `rtol=1e-10` to handle numerical rounding
 """
 function indFromT(tspan, tstops, t)
     return [val==tspan[1] ?
-            findfirst(_t->(isapprox(_t, val, rtol = 1e-7)), t) : # If this corresponds to the initial state, keep the first time step that corresponds in order to avoid issues with out of range interpolation.
-            findlast(_t->(isapprox(_t, val, rtol = 1e-7)), t) # Otherwise, keep the last time step that corresponds. This is to get the state after a potential CB has been applied.
+            findfirst(_t->(isapprox(_t, val, rtol = 1e-10)), t) : # If this corresponds to the initial state, keep the first time step that corresponds in order to avoid issues with out of range interpolation.
+            findlast(_t->(isapprox(_t, val, rtol = 1e-10)), t) # Otherwise, keep the last time step that corresponds. This is to get the state after a potential CB has been applied.
             for val in tstops] # We use isapprox because of potential numerical roundings
 end
 


### PR DESCRIPTION
- Utilities implemented by @girodlis to assimilate Millan22 velocities
- Add downscaling of these velocities
- Reduce `rtol` in `indFromT` to fix the tstops mismatch with the manual adjoint in ODINN. The bug is what I suspected: we were selecting the last time steps that was close enough to the desired tstops but the threshold was too large

@JordiBolibar @girodlis before merging this PR we need to decide if we are happy enough with the API of `generate_ground_truth` for the moment (i.e. we could improve this in the future), or if we want to move that piece of code inside `initialize_glacier` based on `params`